### PR TITLE
Remove cssbeautify. Fixes #18.

### DIFF
--- a/lib/combine-mq.js
+++ b/lib/combine-mq.js
@@ -15,7 +15,6 @@
  chalk = require('chalk'),
  mkdirp = require('mkdirp'),
  parseCss = require('css-parse'),
- cssbeautify = require('cssbeautify'),
  superb = require('superb'),
  dammit = require('dammit');
  /**
@@ -457,15 +456,6 @@ var i = 0;
 		// Hack to get over the darn .editorconfig issue >:( //
 			strStyles += '\n';
 		//////////////////// @todo fix this ///////////////////
-
-
-		// Beautify output if requested
-		if (options.beautify) {
-			strStyles = cssbeautify(strStyles, {
-				autosemicolon: true,
-				indent: '  '
-			});
-		}
 
 		if (!options.dest) {
 			return strStyles;

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
 		"commander": "^2.3.0",
 		"css-parse": "^2.0.0",
 		"css-stringify": "^2.0.0",
-		"cssbeautify": "^0.3.1",
 		"dammit": "^0.5.1",
 		"mkdirp": "^0.5.0",
 		"superb": "^1.0.3"


### PR DESCRIPTION
Recommended to bump the version to `1.0.0` as this is now a breaking change.